### PR TITLE
Add Jama API documentation folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,3 +163,6 @@ def get_current_user():
 - Dockerize & deploy  
 
 Feel free to fork and expand!
+
+## Project Documentation
+Additional guides and notes live in the [`docs/`](docs/) directory.

--- a/docs/client-credentials.md
+++ b/docs/client-credentials.md
@@ -1,0 +1,25 @@
+# Obtaining Jama Client ID and Client Secret
+
+To authenticate with Jama via OAuth you need a **Client ID** and **Client Secret**. The detailed steps for generating these credentials are described in the Jama developer guide at [dev.jamasoftware.com/api](https://dev.jamasoftware.com/api/). Below is a condensed walkthrough.
+
+1. **Open User Profile**
+   - Log in to your Jama instance in a web browser.
+   - Click your avatar in the top right and choose **Profile**.
+
+2. **Set API Credentials**
+   - On the profile page click **Set API Credentials**.
+   - Provide a name for your application or integration.
+   - Click **Create API Credentials**.
+
+3. **Copy the Client ID and Secret**
+   - Jama displays the generated **Client ID** and **Client Secret** once.
+   - Record both values immediately. The secret cannot be viewed again later.
+
+4. **Use the Credentials in OAuth**
+   - To exchange the credentials for an access token, make a `POST` request to `/rest/oauth/token` on your Jama server.
+   - Send `grant_type=client_credentials` in the body and authenticate using HTTP Basic Auth with the Client ID as the username and the Client Secret as the password.
+   - The response contains an `access_token` and an `expires_in` duration (usually one hour).
+
+Repeat the token request whenever the access token expires. You can now call Jama REST endpoints by including the access token in the `Authorization: Bearer` header.
+
+For screenshots and more details, consult the full guide at <https://dev.jamasoftware.com/api/>.

--- a/docs/jama-rest-api.md
+++ b/docs/jama-rest-api.md
@@ -1,0 +1,37 @@
+# Jama REST API Overview
+
+The official documentation for Jama's REST API is hosted at [rest.jamasoftware.com](https://rest.jamasoftware.com/). It describes all available endpoints, parameters, response formats and authentication details. Below is a short overview of what you can find there.
+
+## Endpoint Catalog
+
+The site lists every REST endpoint grouped by resource type. Some of the main endpoint groups include:
+
+- **abstractitems** – generic access to items, test plans, test cycles, test runs and attachments
+- **activities** – recent activity in the system
+- **attachments** – file attachments to items
+- **baselines** – baseline snapshots of projects
+- **categories** – item categories and components
+- **comments** – threaded comments on items
+- **files** – file uploads used by attachments
+- **filters** – saved filters for item queries
+- **items** – core CRUD operations for project items
+- **itemtypes** – definitions of item types for projects
+- **picklistoptions** and **picklists** – custom pick list values
+- **projects** – project metadata and permissions
+- **relationshiprulesets**, **relationships** and **relationshiptypes** – linking items to each other
+- **releases** – versioned releases in a project
+- **system** – server version and configuration info
+- **tags** – labels that can be applied to items
+- **testcycles**, **testruns** and **testplans** – test management resources
+- **users** and **usergroups** – user accounts and groups
+
+Each endpoint page details all supported HTTP methods (such as `GET`, `POST`, `PUT` and `DELETE`), required and optional parameters, sample requests and example responses.
+
+## API Version and Formats
+
+The current documentation covers REST API **v1** which ships with Jama Connect **9.12**. Requests and responses use JSON. Many operations support filtering, pagination and sorting through query parameters.
+
+The site also explains the available authentication methods. Basic authentication is supported for non-SSO environments. Jama Cloud or self-hosted versions starting with 8.62 can also authenticate via OAuth using client credentials.
+
+For complete details visit <https://rest.jamasoftware.com/> and browse the full list of operations.
+


### PR DESCRIPTION
## Summary
- create `docs/` directory for project documentation
- add overview of Jama REST API endpoints
- document how to obtain Jama client credentials
- mention new docs directory in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68510d77c624832bb25cae91bf2ddbe1