### PR TITLE
Add CLI and alias /me endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # jama-openapi-tool
 
 **Minimal FastAPI proxy for Jama Connect**  
-Expose a single `/me` endpoint to fetch the current user’s info via OAuth2 Client Credentials.  
+Expose a `/users/current` endpoint (aliased at `/me`) to fetch the current user’s info via OAuth2 Client Credentials.
 Designed for incremental expansion—add more Jama routes as you go.
 
 ---
@@ -11,8 +11,9 @@ Designed for incremental expansion—add more Jama routes as you go.
 
 - 🔒 OAuth2 Client Credentials (Client ID + Client Secret)  
 - 📦 `.env` support via `python-dotenv`  
-- ⚡ Single `/me` endpoint to get authenticated user profile  
-- 🌐 CORS enabled for GET  
+- ⚡ `/users/current` endpoint (with `/me` alias) to get authenticated user profile
+- 🌐 CORS enabled for GET
+- 🖥 Simple CLI for launching the server
 
 ---
 
@@ -26,9 +27,17 @@ Designed for incremental expansion—add more Jama routes as you go.
 
 ## Installation
 
-1. Clone the repo  
+Install directly from GitHub:
+```bash
+pip install git+https://github.com/Wenlin-AI/jama-openapi-tool.git
+```
+
+Or clone and install locally:
+
+
+1. Clone the repo
    ```bash
-   git clone https://github.com/your-org/jama-openapi-tool.git
+   git clone https://github.com/Wenlin-AI/jama-openapi-tool.git
    cd jama-openapi-tool
    ```
 
@@ -40,7 +49,7 @@ Designed for incremental expansion—add more Jama routes as you go.
 
 3. Install dependencies  
    ```bash
-   pip install fastapi uvicorn py-jama-rest-client python-dotenv
+   pip install -e .
    ```
 
 ---
@@ -62,20 +71,20 @@ JAMA_CLIENT_SECRET=your_client_secret
 
 ## Running
 
-Start the FastAPI app with Uvicorn:
+Start the FastAPI app using the bundled CLI:
 
 ```bash
-uvicorn app:app --reload --port 8000
+jama-openapi-tool --port 8000
 ```
 
-- Open `http://localhost:8000/docs` for interactive Swagger UI  
-- Call `GET /me` to fetch your own user profile  
+- Open `http://localhost:8000/docs` for interactive Swagger UI
+- Call `GET /me` (or `/users/current`) to fetch your own user profile
 
 ---
 
 ## Endpoint
 
-### GET /me
+### GET /users/current (alias: `/me`)
 
 Fetch current user’s information from Jama.
 
@@ -137,6 +146,7 @@ class User(BaseModel):
     lastName: str
     email: str
 
+@app.get("/users/current", response_model=User, summary="Get current authenticated user")
 @app.get("/me", response_model=User, summary="Get current authenticated user")
 def get_current_user():
     try:

--- a/jama_openapi_tool/__main__.py
+++ b/jama_openapi_tool/__main__.py
@@ -1,0 +1,19 @@
+import argparse
+from uvicorn import run
+from .app import app
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run Jama OpenAPI Tool")
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port to run the FastAPI server",
+    )
+    args = parser.parse_args()
+    run(app, host="127.0.0.1", port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/jama_openapi_tool/app.py
+++ b/jama_openapi_tool/app.py
@@ -1,0 +1,63 @@
+import os
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+from dotenv import load_dotenv
+from py_jama_rest_client.client import JamaClient
+
+load_dotenv()
+
+client = JamaClient(
+    os.getenv("JAMA_BASE_URL"),
+    credentials=(
+        os.getenv("JAMA_CLIENT_ID"),
+        os.getenv("JAMA_CLIENT_SECRET"),
+    ),
+    oauth=True,
+)
+
+app = FastAPI(
+    title="Jama Toolset",
+    version="0.1.0",
+    description="Minimal proxy for Jama Connect — only current user info",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["GET"],
+    allow_headers=["*"],
+)
+
+class User(BaseModel):
+    id: int
+    username: str
+    firstName: str
+    lastName: str
+    email: str
+
+
+def _fetch_current_user() -> User:
+    """Retrieve the current Jama user."""
+    try:
+        u = client.get_current_user()
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=str(e))
+
+    return User(
+        id=u["id"],
+        username=u["username"],
+        firstName=u["firstName"],
+        lastName=u["lastName"],
+        email=u["email"],
+    )
+
+
+@app.get("/users/current", response_model=User, summary="Get current authenticated user")
+def get_current_user():
+    return _fetch_current_user()
+
+
+@app.get("/me", response_model=User, summary="Get current authenticated user")
+def get_me():
+    return _fetch_current_user()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "jama-openapi-tool"
+version = "0.1.0"
+description = "Minimal FastAPI proxy for Jama Connect"
+authors = [{name = "Henri Wenlin", email = "henri.wenlin@gmail.com"}]
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "fastapi",
+    "uvicorn",
+    "py-jama-rest-client",
+    "python-dotenv",
+]
+
+[project.urls]
+Homepage = "https://github.com/Wenlin-AI/jama-openapi-tool"
+
+[project.scripts]
+jama-openapi-tool = "jama_openapi_tool.__main__:main"


### PR DESCRIPTION
## Summary
- add simple CLI entrypoint
- implement `/me` alias for `/users/current`
- update docs for new GitHub URL, CLI usage, and alias endpoint
- set project metadata for Henri Wenlin

## Testing
- `python -m py_compile jama_openapi_tool/app.py jama_openapi_tool/__main__.py`
- `pip install -e .`

------
https://chatgpt.com/codex/tasks/task_e_68510c55c044832b87b588a08f0dcb20