### PR TITLE
Hide old endpoint and warn if port in use

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # jama-openapi-tool
 
 **Minimal FastAPI proxy for Jama Connect**  
-Expose a `/users/current` endpoint (aliased at `/me`) to fetch the current user’s info via OAuth2 Client Credentials.
+Expose a `/me` endpoint to fetch the current user’s info via OAuth2 Client Credentials. The legacy `/users/current` route still works but is hidden from the public docs.
 Designed for incremental expansion—add more Jama routes as you go.
 
 ---
@@ -11,7 +11,7 @@ Designed for incremental expansion—add more Jama routes as you go.
 
 - 🔒 OAuth2 Client Credentials (Client ID + Client Secret)  
 - 📦 `.env` support via `python-dotenv`  
-- ⚡ `/users/current` endpoint (with `/me` alias) to get authenticated user profile
+- ⚡ `/me` endpoint for the authenticated user (legacy `/users/current` hidden)
 - 🌐 CORS enabled for GET
 - 🖥 Simple CLI for launching the server
 
@@ -78,15 +78,15 @@ jama-openapi-tool --port 8000
 ```
 
 - Open `http://localhost:8000/docs` for interactive Swagger UI
-- Call `GET /me` (or `/users/current`) to fetch your own user profile
+- Call `GET /me` to fetch your own user profile (the `/users/current` alias is hidden from docs)
 
 ---
 
 ## Endpoint
 
-### GET /users/current (alias: `/me`)
+### GET /me (alias: `/users/current`)
 
-Fetch current user’s information from Jama.
+Fetch current user’s information from Jama. The `/users/current` path is still available but excluded from the OpenAPI schema.
 
 **Response** (200):
 
@@ -146,7 +146,12 @@ class User(BaseModel):
     lastName: str
     email: str
 
-@app.get("/users/current", response_model=User, summary="Get current authenticated user")
+@app.get(
+    "/users/current",
+    response_model=User,
+    summary="Get current authenticated user",
+    include_in_schema=False,
+)
 @app.get("/me", response_model=User, summary="Get current authenticated user")
 def get_current_user():
     try:

--- a/jama_openapi_tool/__main__.py
+++ b/jama_openapi_tool/__main__.py
@@ -1,4 +1,5 @@
 import argparse
+import socket
 from uvicorn import run
 from .app import app
 
@@ -12,6 +13,12 @@ def main():
         help="Port to run the FastAPI server",
     )
     args = parser.parse_args()
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        if sock.connect_ex(("127.0.0.1", args.port)) == 0:
+            print(f"Port {args.port} is already in use. Choose a different port.")
+            return
+
     run(app, host="127.0.0.1", port=args.port)
 
 

--- a/jama_openapi_tool/app.py
+++ b/jama_openapi_tool/app.py
@@ -53,7 +53,12 @@ def _fetch_current_user() -> User:
     )
 
 
-@app.get("/users/current", response_model=User, summary="Get current authenticated user")
+@app.get(
+    "/users/current",
+    response_model=User,
+    summary="Get current authenticated user",
+    include_in_schema=False,
+)
 def get_current_user():
     return _fetch_current_user()
 


### PR DESCRIPTION
## Summary
- keep `/users/current` for compatibility but hide it from OpenAPI docs
- warn when running the CLI if the chosen port is already taken
- update README to document the new behavior

## Testing
- `python -m compileall jama_openapi_tool`
- `python -m jama_openapi_tool --port 9999` *(fails: ModuleNotFoundError: No module named 'uvicorn')*

------
https://chatgpt.com/codex/tasks/task_e_6851221bc830832b966652372f2f4934